### PR TITLE
Fix curl options to surface errors

### DIFF
--- a/src/flux-mcp-server/NOTES.md
+++ b/src/flux-mcp-server/NOTES.md
@@ -17,4 +17,5 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 1.0.1 | Surface curl errors |
 | 1.0.0 | Initial release |

--- a/src/flux-mcp-server/devcontainer-feature.json
+++ b/src/flux-mcp-server/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "flux-mcp-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Flux MCP Server",
   "documentationURL": "https://fluxcd.control-plane.io/mcp/",
   "description": "The Flux Model Context Protocol (MCP) Server connects AI assistants like Claude, Cursor, GitHub Copilot, and others directly to your Kubernetes clusters running Flux Operator, enabling seamless interaction through natural language.",

--- a/src/flux-mcp-server/install.sh
+++ b/src/flux-mcp-server/install.sh
@@ -37,10 +37,10 @@ else
       apt-get -yq install jq
       echo "jq installation complete!"
     fi
-    FLUX_MCP_SERVER_RELEASE=$(curl -sL https://api.github.com/repos/controlplaneio-fluxcd/flux-operator/releases/latest | jq -r '.tag_name | split("v")[1]')
-    curl -sL https://github.com/controlplaneio-fluxcd/flux-operator/releases/latest/download/flux-operator-mcp_${FLUX_MCP_SERVER_RELEASE}_linux_${FLUX_MCP_SERVER_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ flux-operator-mcp
+    FLUX_MCP_SERVER_RELEASE=$(curl -sSL https://api.github.com/repos/controlplaneio-fluxcd/flux-operator/releases/latest | jq -r '.tag_name | split("v")[1]')
+    curl -sSL https://github.com/controlplaneio-fluxcd/flux-operator/releases/latest/download/flux-operator-mcp_${FLUX_MCP_SERVER_RELEASE}_linux_${FLUX_MCP_SERVER_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ flux-operator-mcp
   else
-    curl -sL https://github.com/controlplaneio-fluxcd/flux-operator/releases/download/v${FLUX_MCP_SERVER_VERSION}/flux-operator-mcp_${FLUX_MCP_SERVER_VERSION}_linux_${FLUX_MCP_SERVER_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ flux-operator-mcp
+    curl -sSL https://github.com/controlplaneio-fluxcd/flux-operator/releases/download/v${FLUX_MCP_SERVER_VERSION}/flux-operator-mcp_${FLUX_MCP_SERVER_VERSION}_linux_${FLUX_MCP_SERVER_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ flux-operator-mcp
   fi
 fi
 

--- a/src/flux/NOTES.md
+++ b/src/flux/NOTES.md
@@ -17,4 +17,5 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 1.0.1 | Surface curl errors |
 | 1.0.0 | Initial release |

--- a/src/flux/devcontainer-feature.json
+++ b/src/flux/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "flux",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Flux",
   "documentationURL": "https://fluxcd.io/flux/cmd/",
   "description": "Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit.",

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -24,9 +24,9 @@ if [ "${FLUX_VERSION}" = "none" ] || type flux > /dev/null 2>&1; then
 else
   echo "Installing flux..."
   if [ "${FLUX_VERSION}" = "latest" ] ; then
-    curl -s https://fluxcd.io/install.sh | bash
+    curl -sS https://fluxcd.io/install.sh | bash
   else
-    curl -s https://fluxcd.io/install.sh | FLUX_VERSION=$FLUX_VERSION bash
+    curl -sS https://fluxcd.io/install.sh | FLUX_VERSION=$FLUX_VERSION bash
   fi
 fi
 

--- a/src/kube-linter/NOTES.md
+++ b/src/kube-linter/NOTES.md
@@ -17,4 +17,5 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 1.0.1 | Surface curl errors |
 | 1.0.0 | Initial release |

--- a/src/kube-linter/devcontainer-feature.json
+++ b/src/kube-linter/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kube-linter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "KubeLinter",
   "documentationURL": "https://docs.kubelinter.io/#/",
   "description": "KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices.",

--- a/src/kube-linter/install.sh
+++ b/src/kube-linter/install.sh
@@ -28,9 +28,9 @@ if [ "${KUBE_LINTER_VERSION}" = "none" ] || type kube-linter > /dev/null 2>&1; t
 else
   echo "Installing kube-linter..."
   if [ "${KUBE_LINTER_VERSION}" = "latest" ] ; then
-    curl -sL https://github.com/stackrox/kube-linter/releases/latest/download/kube-linter-linux${KUBE_LINTER_ARCH} -o /usr/local/bin/kube-linter && chmod +x /usr/local/bin/kube-linter
+    curl -sSL https://github.com/stackrox/kube-linter/releases/latest/download/kube-linter-linux${KUBE_LINTER_ARCH} -o /usr/local/bin/kube-linter && chmod +x /usr/local/bin/kube-linter
   else
-    curl -sL https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter-linux${KUBE_LINTER_ARCH} -o /usr/local/bin/kube-linter && chmod +x /usr/local/bin/kube-linter
+    curl -sSL https://github.com/stackrox/kube-linter/releases/download/${KUBE_LINTER_VERSION}/kube-linter-linux${KUBE_LINTER_ARCH} -o /usr/local/bin/kube-linter && chmod +x /usr/local/bin/kube-linter
   fi
 fi
 

--- a/src/kubeconform/NOTES.md
+++ b/src/kubeconform/NOTES.md
@@ -17,5 +17,6 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 1.0.2 | Surface curl errors |
 | 1.0.1 | Fix curl option typo |
 | 1.0.0 | Initial release |

--- a/src/kubeconform/devcontainer-feature.json
+++ b/src/kubeconform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kubeconform",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "Kubeconform",
   "documentationURL": "https://github.com/yannh/kubeconform?tab=readme-ov-file#usage",
   "description": "Kubeconform is a Kubernetes manifest validation tool.",

--- a/src/kubeconform/install.sh
+++ b/src/kubeconform/install.sh
@@ -28,9 +28,9 @@ if [ "${KUBECONFORM_VERSION}" = "none" ] || type kubeconform > /dev/null 2>&1; t
 else
   echo "Installing kubeconform..."
   if [ "${KUBECONFORM_VERSION}" = "latest" ] ; then
-    curl -sL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-${KUBECONFORM_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ kubeconform
+    curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-${KUBECONFORM_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ kubeconform
   else
-    curl -sL https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-${KUBECONFORM_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ kubeconform
+    curl -sSL https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-${KUBECONFORM_ARCH}.tar.gz | tar xzf - -C /usr/local/bin/ kubeconform
   fi
 fi
 

--- a/src/kustomize/NOTES.md
+++ b/src/kustomize/NOTES.md
@@ -17,4 +17,5 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 1.0.1 | Surface curl errors |
 | 1.0.0 | Initial release |

--- a/src/kustomize/devcontainer-feature.json
+++ b/src/kustomize/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "kustomize",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Kustomize",
   "documentationURL": "https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/",
   "description": "Kustomize lets you customize raw, template-free YAML files for multiple purposes, leaving the original YAML untouched and usable as is.",

--- a/src/kustomize/install.sh
+++ b/src/kustomize/install.sh
@@ -22,9 +22,9 @@ if [ "${KUSTOMIZE_VERSION}" = "none" ] || type kustomize > /dev/null 2>&1; then
 else
   echo "Installing kustomize..."
   if [ "${KUSTOMIZE_VERSION}" = "latest" ] ; then
-    curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s -- /usr/local/bin
+    curl -sS https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s -- /usr/local/bin
   else
-    curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s -- $KUSTOMIZE_VERSION /usr/local/bin
+    curl -sS https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash -s -- $KUSTOMIZE_VERSION /usr/local/bin
   fi
 fi
 


### PR DESCRIPTION
This PR updates most install scripts to utilize `curl -S` in order to surface errors (if any).