### PR TITLE
Remove autocomplete command for terraform feature

### DIFF
--- a/src/terraform/NOTES.md
+++ b/src/terraform/NOTES.md
@@ -14,6 +14,7 @@ Versions older than what are listed above are untested and therefore may not sup
 
 | Version | Notes |
 | --- | --- |
+| 3.0.0 | Remove autocomplete input |
 | 2.0.0 | Simplify install script |
 | 1.2.0 | Set VS Code to auto-format Terraform files on save |
 | 1.1.1 | Cleanup Terraform feature |

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Terraform",
   "id": "terraform",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Installs the Terraform CLI.",
   "options": {
     "version": {
@@ -12,11 +12,6 @@
         "1.9.1"
       ],
       "type": "string"
-    },
-    "autocomplete": {
-      "type": "boolean",
-      "default": true,
-      "description": "Enable shell tab-completion"
     }
   },
   "customizations": {
@@ -38,5 +33,6 @@
   },
   "dependsOn": {
     "ghcr.io/devcontainers/features/common-utils": {}
-  }
+  },
+  "postCreateCommand": "echo 'complete -C /usr/local/bin/terraform terraform' >> ~/.bashrc"
 }

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -3,7 +3,6 @@
 set -e
 
 VERSION="${VERSION:-latest}"
-AUTOCOMPLETE="${AUTOCOMPLETE:-true}"
 binary_name="terraform"
 
 arch=$(uname -m | sed 's/aarch64/arm64/; s/x86_64/amd64/')
@@ -20,39 +19,7 @@ else
   fi
   curl -sSLO https://releases.hashicorp.com/${binary_name}/${binary_version}/${binary_name}_${binary_version}_linux_${arch}.zip && unzip -jq ${binary_name}_${binary_version}_linux_${arch}.zip ${binary_name} -d /usr/local/bin/
   rm -f ${binary_name}_${binary_version}_linux_${arch}.zip
-fi
-
-if [ "${AUTOCOMPLETE}" = "true" ]; then
-  echo "Installing ${binary_name} bash autocompletion..."
-  sudo -iu "$_REMOTE_USER" <<EOF
-    # https://github.com/devcontainers-contrib/features/blob/9a1d24b27b2d1ea8916ebe49c9ce674375dced27/src/pulumi/install.sh
-    set -eo pipefail
-    if [ "$_REMOTE_USER" == "root" ]; then
-      USER_LOCATION="/root"
-      echo "$_REMOTE_USER HOME is \$USER_LOCATION"
-    else
-      USER_LOCATION="/home/$_REMOTE_USER"
-      echo "$_REMOTE_USER HOME is \$USER_LOCATION"
-    fi
-    cd \$USER_LOCATION
-    echo "Changed to \$USER_LOCATION"
-    if [ -n "$($SHELL -c 'echo $BASH_VERSION')" ]; then
-      echo "$SHELL detected"
-      if [ ! -f "\$USER_LOCATION/.bashrc" ] || [ ! -s "\$USER_LOCATION/.bashrc" ]; then
-        echo ".bashrc missing"
-        sudo cp  /etc/skel/.bashrc "\$USER_LOCATION/.bashrc"
-        echo ".bashrc copied"
-      fi
-      if  [ ! -f "\$USER_LOCATION/.profile" ] || [ ! -s "\$USER_LOCATION/.profile" ]; then
-        echo ".profile missing"
-        sudo cp  /etc/skel/.profile "\$USER_LOCATION/.profile"
-        echo ".profile copied"
-      fi
-      $binary_name -install-autocomplete
-      . \$USER_LOCATION/.bashrc
-      echo "$binary_name bash autocompletion installed successfully!"
-    fi
-EOF
+  echo "$binary_name installed."
 fi
 
 set +e


### PR DESCRIPTION
This PR removes the input for autocomplete and enables it by default for all installations. While it doesn't actually remove anything feature-wise, it does take away user choice so I am releasing this as v3.0.0.