### PR TITLE
Add github-cli-extras feature

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -3,6 +3,7 @@ age: ./**/age/**
 claude-code: ./**/claude-code/**
 flux: ./**/flux/**
 flux-mcp-server: ./**/flux-mcp-server/**
+github-cli-extras: ./**/github-cli-extras/**
 github-mcp-server: ./**/github-mcp-server/**
 hcloud: ./**/hcloud/**
 kube-linter: ./**/kube-linter/**

--- a/src/github-cli-extras/NOTES.md
+++ b/src/github-cli-extras/NOTES.md
@@ -1,0 +1,17 @@
+
+## OS Support
+
+This feature is tested against the following OS versions:
+
+- ubuntu:noble
+- debian:12
+- mcr.microsoft.com/devcontainers/base:ubuntu
+- mcr.microsoft.com/devcontainers/base:debian
+
+Versions older than what are listed above are untested and therefore may not support this feature without additional packages.
+
+## Changelog
+
+| Version | Notes |
+| --- | --- |
+| 1.0.0 | Initial release |

--- a/src/github-cli-extras/devcontainer-feature.json
+++ b/src/github-cli-extras/devcontainer-feature.json
@@ -1,0 +1,19 @@
+{
+  "id": "github-cli-extras",
+  "version": "1.0.0",
+  "name": "GitHub CLI Extras",
+  "documentationURL": "https://github.com/bendwyer/devcontainer-features/tree/main/src/github-cli-extras",
+  "description": "Adds data persistence for the GitHub CLI (gh).",
+  "options": {},
+  "dependsOn": {
+    "ghcr.io/devcontainers/features/github-cli": {}
+  },
+  "postCreateCommand": "/usr/local/share/github-cli-extras/setup.sh",
+  "mounts": [
+    {
+      "source": "${containerWorkspaceFolderBasename}-github-cli",
+      "target": "/var/lib/gh",
+      "type": "volume"
+    }
+  ]
+}

--- a/src/github-cli-extras/devcontainer-feature.json
+++ b/src/github-cli-extras/devcontainer-feature.json
@@ -6,6 +6,7 @@
   "description": "Adds data persistence for the GitHub CLI (gh).",
   "options": {},
   "dependsOn": {
+    "ghcr.io/devcontainers/features/common-utils": {},
     "ghcr.io/devcontainers/features/github-cli": {}
   },
   "postCreateCommand": "/usr/local/share/github-cli-extras/setup.sh",

--- a/src/github-cli-extras/install.sh
+++ b/src/github-cli-extras/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+GH_DATA_DIR="/var/lib/gh"
+SETUP_SCRIPT_DIR="/usr/local/share/github-cli-extras"
+
+# Ensure the mount point exists
+mkdir -p "$GH_DATA_DIR"
+
+# Copy the setup script to a well-known location for postCreateCommand
+mkdir -p "$SETUP_SCRIPT_DIR"
+cp setup.sh "$SETUP_SCRIPT_DIR/setup.sh"
+chmod +x "$SETUP_SCRIPT_DIR/setup.sh"

--- a/src/github-cli-extras/setup.sh
+++ b/src/github-cli-extras/setup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+GH_DATA_DIR="/var/lib/gh"
+GH_CONFIG_DIR="$HOME/.config/gh"
+
+# Take ownership of the mount point
+sudo chown "$(whoami)" "$GH_DATA_DIR"
+
+# Migrate existing config into the volume if it exists and isn't already a symlink
+if [ -d "$GH_CONFIG_DIR" ] && [ ! -L "$GH_CONFIG_DIR" ]; then
+    cp -a "$GH_CONFIG_DIR/." "$GH_DATA_DIR/" 2>/dev/null
+    rm -rf "$GH_CONFIG_DIR"
+fi
+
+# Symlink ~/.config/gh to the persistent volume
+mkdir -p "$HOME/.config"
+ln -sfn "$GH_DATA_DIR" "$GH_CONFIG_DIR"

--- a/test/github-cli-extras/test.sh
+++ b/test/github-cli-extras/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "user" whoami
+check "gh cli location" which gh
+check "gh cli version" gh --version
+check "gh config dir exists" ls -ld /var/lib/gh
+check "gh config dir is writable" bash -c "test -w /var/lib/gh && echo writable"
+check "gh config symlink exists" bash -c "test -L ~/.config/gh && readlink ~/.config/gh | grep /var/lib/gh"
+check "volume is mounted" bash -c "mount | grep /var/lib/gh"
+# Report result
+reportResults


### PR DESCRIPTION
The github-cli-extras feature extends the gh cli feature by adding data persistence for config data.