### PR TITLE
Add ansible-mcp-server feature

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,5 +1,6 @@
 ---
 age: ./**/age/**
+ansible-mcp-server: ./**/ansible-mcp-server/**
 claude-code: ./**/claude-code/**
 flux: ./**/flux/**
 flux-mcp-server: ./**/flux-mcp-server/**

--- a/src/ansible-mcp-server/NOTES.md
+++ b/src/ansible-mcp-server/NOTES.md
@@ -1,0 +1,20 @@
+
+## OS Support
+
+This feature is tested against the following images:
+
+- ubuntu:24.04
+- debian:12
+- mcr.microsoft.com/devcontainers/base:ubuntu24.04
+- mcr.microsoft.com/devcontainers/base:debian12
+
+This feature is tested against the following architectures:
+
+- amd64
+- arm64
+
+## Changelog
+
+| Version | Notes |
+| --- | --- |
+| 1.0.0 | Initial release |

--- a/src/ansible-mcp-server/devcontainer-feature.json
+++ b/src/ansible-mcp-server/devcontainer-feature.json
@@ -1,0 +1,21 @@
+{
+  "id": "ansible-mcp-server",
+  "version": "1.0.0",
+  "name": "Ansible MCP Server (via npm)",
+  "documentationURL": "https://docs.ansible.com/projects/vscode-ansible/mcp/",
+  "description": "The Ansible Development Tools MCP (Model Context Protocol) Server enables AI assistants and language models to interact with Ansible tooling through a standardized protocol.",
+  "options": {
+    "version": {
+      "default": "latest",
+      "description": "Select the version to install. Anything that is not 'latest' must be in '#.#.#' format.",
+      "proposals": [
+        "latest",
+        "0.1.0"
+      ],
+      "type": "string"
+    }
+  },
+  "dependsOn": {
+    "ghcr.io/devcontainers/features/node": {}
+  }
+}

--- a/src/ansible-mcp-server/install.sh
+++ b/src/ansible-mcp-server/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION="${VERSION:-latest}"
+
+npm install -g @ansible/ansible-mcp-server@$VERSION

--- a/test/ansible-mcp-server/ansible_mcp_server_version.sh
+++ b/test/ansible-mcp-server/ansible_mcp_server_version.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+echo ""
+echo "Running as $(whoami)"
+check "ansible-mcp-server location" which ansible-mcp-server
+check "ansible-mcp-server output" ansible-mcp-server
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/ansible-mcp-server/scenarios.json
+++ b/test/ansible-mcp-server/scenarios.json
@@ -1,0 +1,10 @@
+{
+  "ansible_mcp_server_version": {
+    "image": "mcr.microsoft.com/devcontainers/base:debian12",
+    "features": {
+      "ansible-mcp-server": {
+        "version": "0.1.0"
+      }
+    }
+  }
+}

--- a/test/ansible-mcp-server/test.sh
+++ b/test/ansible-mcp-server/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+echo ""
+echo "Running as $(whoami)"
+check "ansible-mcp-server location" which ansible-mcp-server
+check "ansible-mcp-server output" ansible-mcp-server
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
This PR adds the [ansible-mcp-server](https://docs.ansible.com/projects/vscode-ansible/mcp/) feature