### PR TITLE
Refactor bash completion and required packages

### DIFF
--- a/src/flux/devcontainer-feature.json
+++ b/src/flux/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
-  "id": "flux",
-  "version": "1.1.0",
   "name": "Flux",
+  "id": "flux",
+  "version": "2.0.0",
   "documentationURL": "https://fluxcd.io/flux/cmd/",
   "description": "Open and extensible continuous delivery solution for Kubernetes. Powered by GitOps Toolkit.",
   "options": {
@@ -20,9 +20,5 @@
         "ms-kubernetes-tools.vscode-kubernetes-tools"
       ]
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'source /usr/share/bash-completion/bash_completion; source <(flux completion bash)' >> ~/.bashrc"
+  }
 }

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -39,24 +39,20 @@ fi
 target_user="${_REMOTE_USER:-root}"
 echo "Installing bash completion for ${binary_name} for ${target_user}..."
 if [ "${target_user}" = "root" ]; then
-    target_home="/root"
+    target_bashrc="/root/.bashrc"
 else
-    target_home="/home/${target_user}"
+    target_bashrc="/home/${target_user}/.bashrc"
 fi
-target_bashrc="${target_home}/.bashrc"
-mkdir -p "${target_home}"
-if [ ! -s "${target_bashrc}" ]; then
-    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
-fi
-completion_line="source <(${binary_name} completion bash)"
-if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+completion_marker="# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+if ! grep -qF "${completion_marker}" "${target_bashrc}" 2>/dev/null; then
     {
         echo ""
-        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
-        echo "${completion_line}"
+        echo "${completion_marker}"
+        echo "source /usr/share/bash-completion/bash_completion"
+        echo "source <(${binary_name} completion bash)"
     } >> "${target_bashrc}"
 fi
-chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
+chown "${target_user}:${target_user}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq sudo)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,16 +36,27 @@ else
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}_${binary_version}_linux_${arch}.tar.gz | tar xzf - -C /usr/local/bin/ ${binary_name}
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
-if [ -r /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+if [ "${target_user}" = "root" ]; then
+    target_home="/root"
+else
+    target_home="/home/${target_user}"
 fi
-if command -v ${binary_name} > /dev/null 2>&1; then
-    source <(${binary_name} completion bash)
+target_bashrc="${target_home}/.bashrc"
+mkdir -p "${target_home}"
+if [ ! -s "${target_bashrc}" ]; then
+    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
 fi
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+completion_line="source <(${binary_name} completion bash)"
+if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+        echo "${completion_line}"
+    } >> "${target_bashrc}"
+fi
+chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(bash-completion curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="flux"
 owner_name="fluxcd"
@@ -21,6 +35,18 @@ else
   fi
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}_${binary_version}_linux_${arch}.tar.gz | tar xzf - -C /usr/local/bin/ ${binary_name}
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
+if [ -r /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+fi
+if command -v ${binary_name} > /dev/null 2>&1; then
+    source <(${binary_name} completion bash)
+fi
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/flux/install.sh
+++ b/src/flux/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/hcloud/devcontainer-feature.json
+++ b/src/hcloud/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Hetzner Cloud CLI",
   "id": "hcloud",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A command-line interface for Hetzner Cloud.",
   "options": {
     "version": {
@@ -13,9 +13,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'source /usr/share/bash-completion/bash_completion; source <(hcloud completion bash)' >> ~/.bashrc"
+  }
 }

--- a/src/hcloud/install.sh
+++ b/src/hcloud/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq sudo)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,16 +36,27 @@ else
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-linux-${arch}.tar.gz | tar xzf - -C /usr/local/bin/ ${binary_name}
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
-if [ -r /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+if [ "${target_user}" = "root" ]; then
+    target_home="/root"
+else
+    target_home="/home/${target_user}"
 fi
-if command -v ${binary_name} > /dev/null 2>&1; then
-    source <(${binary_name} completion bash)
+target_bashrc="${target_home}/.bashrc"
+mkdir -p "${target_home}"
+if [ ! -s "${target_bashrc}" ]; then
+    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
 fi
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+completion_line="source <(${binary_name} completion bash)"
+if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+        echo "${completion_line}"
+    } >> "${target_bashrc}"
+fi
+chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/hcloud/install.sh
+++ b/src/hcloud/install.sh
@@ -39,24 +39,20 @@ fi
 target_user="${_REMOTE_USER:-root}"
 echo "Installing bash completion for ${binary_name} for ${target_user}..."
 if [ "${target_user}" = "root" ]; then
-    target_home="/root"
+    target_bashrc="/root/.bashrc"
 else
-    target_home="/home/${target_user}"
+    target_bashrc="/home/${target_user}/.bashrc"
 fi
-target_bashrc="${target_home}/.bashrc"
-mkdir -p "${target_home}"
-if [ ! -s "${target_bashrc}" ]; then
-    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
-fi
-completion_line="source <(${binary_name} completion bash)"
-if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+completion_marker="# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+if ! grep -qF "${completion_marker}" "${target_bashrc}" 2>/dev/null; then
     {
         echo ""
-        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
-        echo "${completion_line}"
+        echo "${completion_marker}"
+        echo "source /usr/share/bash-completion/bash_completion"
+        echo "source <(${binary_name} completion bash)"
     } >> "${target_bashrc}"
 fi
-chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
+chown "${target_user}:${target_user}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/hcloud/install.sh
+++ b/src/hcloud/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/hcloud/install.sh
+++ b/src/hcloud/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(bash-completion curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="hcloud"
 owner_name="hetznercloud"
@@ -21,6 +35,18 @@ else
   fi
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-linux-${arch}.tar.gz | tar xzf - -C /usr/local/bin/ ${binary_name}
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
+if [ -r /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+fi
+if command -v ${binary_name} > /dev/null 2>&1; then
+    source <(${binary_name} completion bash)
+fi
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/omnictl/devcontainer-feature.json
+++ b/src/omnictl/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "omnictl",
   "id": "omnictl",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "omnictl is the command-line tool for Omni. It lets you authenticate, manage, and interact with Talos-based Kubernetes clusters through a centralized API.",
   "options": {
     "version": {
@@ -13,9 +13,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'source /usr/share/bash-completion/bash_completion; source <(omnictl completion bash)' >> ~/.bashrc"
+  }
 }

--- a/src/omnictl/install.sh
+++ b/src/omnictl/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq sudo)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,16 +36,27 @@ else
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-linux-${arch} -o /usr/local/bin/${binary_name} && chmod +x /usr/local/bin/${binary_name}
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
-if [ -r /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+if [ "${target_user}" = "root" ]; then
+    target_home="/root"
+else
+    target_home="/home/${target_user}"
 fi
-if command -v ${binary_name} > /dev/null 2>&1; then
-    source <(${binary_name} completion bash)
+target_bashrc="${target_home}/.bashrc"
+mkdir -p "${target_home}"
+if [ ! -s "${target_bashrc}" ]; then
+    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
 fi
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+completion_line="source <(${binary_name} completion bash)"
+if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+        echo "${completion_line}"
+    } >> "${target_bashrc}"
+fi
+chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/omnictl/install.sh
+++ b/src/omnictl/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(bash-completion curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="omnictl"
 owner_name="siderolabs"
@@ -21,6 +35,18 @@ else
   fi
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-linux-${arch} -o /usr/local/bin/${binary_name} && chmod +x /usr/local/bin/${binary_name}
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
+if [ -r /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+fi
+if command -v ${binary_name} > /dev/null 2>&1; then
+    source <(${binary_name} completion bash)
+fi
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/omnictl/install.sh
+++ b/src/omnictl/install.sh
@@ -39,24 +39,20 @@ fi
 target_user="${_REMOTE_USER:-root}"
 echo "Installing bash completion for ${binary_name} for ${target_user}..."
 if [ "${target_user}" = "root" ]; then
-    target_home="/root"
+    target_bashrc="/root/.bashrc"
 else
-    target_home="/home/${target_user}"
+    target_bashrc="/home/${target_user}/.bashrc"
 fi
-target_bashrc="${target_home}/.bashrc"
-mkdir -p "${target_home}"
-if [ ! -s "${target_bashrc}" ]; then
-    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
-fi
-completion_line="source <(${binary_name} completion bash)"
-if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+completion_marker="# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+if ! grep -qF "${completion_marker}" "${target_bashrc}" 2>/dev/null; then
     {
         echo ""
-        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
-        echo "${completion_line}"
+        echo "${completion_marker}"
+        echo "source /usr/share/bash-completion/bash_completion"
+        echo "source <(${binary_name} completion bash)"
     } >> "${target_bashrc}"
 fi
-chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
+chown "${target_user}:${target_user}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/omnictl/install.sh
+++ b/src/omnictl/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/op/devcontainer-feature.json
+++ b/src/op/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "1Password CLI",
   "id": "op",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "1Password CLI brings 1Password to your terminal. Sign in to 1Password CLI with your fingerprint, and securely access everything you need during development.",
   "options": {
     "version": {
@@ -13,9 +13,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'source /usr/share/bash-completion/bash_completion; source <(op completion bash)' >> ~/.bashrc"
+  }
 }

--- a/src/op/install.sh
+++ b/src/op/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion ca-certificates curl unzip)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl sudo unzip)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -35,16 +35,27 @@ else
   rm -f ${binary_name}_linux_${arch}_v${binary_version}.zip
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
-if [ -r /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+if [ "${target_user}" = "root" ]; then
+    target_home="/root"
+else
+    target_home="/home/${target_user}"
 fi
-if command -v ${binary_name} > /dev/null 2>&1; then
-    source <(${binary_name} completion bash)
+target_bashrc="${target_home}/.bashrc"
+mkdir -p "${target_home}"
+if [ ! -s "${target_bashrc}" ]; then
+    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
 fi
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+completion_line="source <(${binary_name} completion bash)"
+if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+        echo "${completion_line}"
+    } >> "${target_bashrc}"
+fi
+chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/op/install.sh
+++ b/src/op/install.sh
@@ -38,24 +38,20 @@ fi
 target_user="${_REMOTE_USER:-root}"
 echo "Installing bash completion for ${binary_name} for ${target_user}..."
 if [ "${target_user}" = "root" ]; then
-    target_home="/root"
+    target_bashrc="/root/.bashrc"
 else
-    target_home="/home/${target_user}"
+    target_bashrc="/home/${target_user}/.bashrc"
 fi
-target_bashrc="${target_home}/.bashrc"
-mkdir -p "${target_home}"
-if [ ! -s "${target_bashrc}" ]; then
-    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
-fi
-completion_line="source <(${binary_name} completion bash)"
-if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+completion_marker="# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+if ! grep -qF "${completion_marker}" "${target_bashrc}" 2>/dev/null; then
     {
         echo ""
-        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
-        echo "${completion_line}"
+        echo "${completion_marker}"
+        echo "source /usr/share/bash-completion/bash_completion"
+        echo "source <(${binary_name} completion bash)"
     } >> "${target_bashrc}"
 fi
-chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
+chown "${target_user}:${target_user}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/op/install.sh
+++ b/src/op/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(bash-completion curl unzip)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="op"
 
@@ -20,6 +34,18 @@ else
   curl -sSLO https://cache.agilebits.com/dist/1P/op2/pkg/v${binary_version}/${binary_name}_linux_${arch}_v${binary_version}.zip && unzip -jq ${binary_name}_linux_${arch}_v${binary_version}.zip ${binary_name} -d /usr/local/bin/
   rm -f ${binary_name}_linux_${arch}_v${binary_version}.zip
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
+if [ -r /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+fi
+if command -v ${binary_name} > /dev/null 2>&1; then
+    source <(${binary_name} completion bash)
+fi
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/op/install.sh
+++ b/src/op/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion curl unzip)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl unzip)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/packer/devcontainer-feature.json
+++ b/src/packer/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
-  "id": "packer",
-  "version": "1.0.1",
   "name": "Packer",
+  "id": "packer",
+  "version": "2.0.0",
   "documentationURL": "https://developer.hashicorp.com/packer/docs",
   "description": "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.",
   "options": {
@@ -13,11 +13,6 @@
         "1.14.1"
       ],
       "type": "string"
-    },
-    "autocomplete": {
-      "type": "boolean",
-      "default": true,
-      "description": "Enable shell tab-completion."
     }
   },
   "customizations": {
@@ -26,8 +21,5 @@
         "hashicorp.hcl"
       ]
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/packer/install.sh
+++ b/src/packer/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(curl jq unzip)
+REQUIRED_PACKAGES=(ca-certificates curl jq unzip)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/packer/install.sh
+++ b/src/packer/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(ca-certificates curl jq unzip)
+REQUIRED_PACKAGES=(ca-certificates curl jq sudo unzip)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,11 +36,9 @@ else
   echo "$binary_name installed."  
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<'EOF'
-complete -C /usr/local/bin/packer packer
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+sudo -u "${target_user}" -H bash -c "${binary_name} -autocomplete-install" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/packer/install.sh
+++ b/src/packer/install.sh
@@ -2,8 +2,21 @@
 
 set -e
 
+REQUIRED_PACKAGES=(curl jq unzip)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
-AUTOCOMPLETE="${AUTOCOMPLETE:-true}"
 binary_name="packer"
 
 arch=$(uname -m | sed 's/aarch64/arm64/; s/x86_64/amd64/')
@@ -20,40 +33,15 @@ else
   fi
   curl -sSLO https://releases.hashicorp.com/${binary_name}/${binary_version}/${binary_name}_${binary_version}_linux_${arch}.zip && unzip -jq ${binary_name}_${binary_version}_linux_${arch}.zip ${binary_name} -d /usr/local/bin/
   rm -f ${binary_name}_${binary_version}_linux_${arch}.zip
+  echo "$binary_name installed."  
 fi
 
-if [ "${AUTOCOMPLETE}" = "true" ]; then
-  echo "Installing ${binary_name} bash autocompletion..."
-  sudo -iu "$_REMOTE_USER" <<EOF
-    # https://github.com/devcontainers-contrib/features/blob/9a1d24b27b2d1ea8916ebe49c9ce674375dced27/src/pulumi/install.sh
-    set -eo pipefail
-    if [ "$_REMOTE_USER" == "root" ]; then
-      USER_LOCATION="/root"
-      echo "$_REMOTE_USER HOME is \$USER_LOCATION"
-    else
-      USER_LOCATION="/home/$_REMOTE_USER"
-      echo "$_REMOTE_USER HOME is \$USER_LOCATION"
-    fi
-    cd \$USER_LOCATION
-    echo "Changed to \$USER_LOCATION"
-    if [ -n "$($SHELL -c 'echo $BASH_VERSION')" ]; then
-      echo "$SHELL detected"
-      if [ ! -f "\$USER_LOCATION/.bashrc" ] || [ ! -s "\$USER_LOCATION/.bashrc" ]; then
-        echo ".bashrc missing"
-        sudo cp  /etc/skel/.bashrc "\$USER_LOCATION/.bashrc"
-        echo ".bashrc copied"
-      fi
-      if  [ ! -f "\$USER_LOCATION/.profile" ] || [ ! -s "\$USER_LOCATION/.profile" ]; then
-        echo ".profile missing"
-        sudo cp  /etc/skel/.profile "\$USER_LOCATION/.profile"
-        echo ".profile copied"
-      fi
-      $binary_name -autocomplete-install
-      . \$USER_LOCATION/.bashrc
-      echo "$binary_name bash autocompletion installed successfully!"
-    fi
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<'EOF'
+complete -C /usr/local/bin/packer packer
 EOF
-fi
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/sops/devcontainer-feature.json
+++ b/src/sops/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
-  "id": "sops",
-  "version": "1.0.0",
   "name": "Secrets OPerationS",
+  "id": "sops",
+  "version": "2.0.0",
   "documentationURL": "https://getsops.io/docs/",
   "description": "Simple and flexible tool for managing secrets.",
   "options": {
@@ -14,9 +14,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'source /usr/share/bash-completion/bash_completion; source <(sops completion bash)' >> ~/.bashrc"
+  }
 }

--- a/src/sops/install.sh
+++ b/src/sops/install.sh
@@ -39,24 +39,20 @@ fi
 target_user="${_REMOTE_USER:-root}"
 echo "Installing bash completion for ${binary_name} for ${target_user}..."
 if [ "${target_user}" = "root" ]; then
-    target_home="/root"
+    target_bashrc="/root/.bashrc"
 else
-    target_home="/home/${target_user}"
+    target_bashrc="/home/${target_user}/.bashrc"
 fi
-target_bashrc="${target_home}/.bashrc"
-mkdir -p "${target_home}"
-if [ ! -s "${target_bashrc}" ]; then
-    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
-fi
-completion_line="source <(${binary_name} completion bash)"
-if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+completion_marker="# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+if ! grep -qF "${completion_marker}" "${target_bashrc}" 2>/dev/null; then
     {
         echo ""
-        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
-        echo "${completion_line}"
+        echo "${completion_marker}"
+        echo "source /usr/share/bash-completion/bash_completion"
+        echo "source <(${binary_name} completion bash)"
     } >> "${target_bashrc}"
 fi
-chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
+chown "${target_user}:${target_user}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/sops/install.sh
+++ b/src/sops/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq sudo)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,16 +36,27 @@ else
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-v${binary_version}.linux.${arch} -o /usr/local/bin/${binary_name} && chmod +x /usr/local/bin/${binary_name}
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
-if [ -r /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+if [ "${target_user}" = "root" ]; then
+    target_home="/root"
+else
+    target_home="/home/${target_user}"
 fi
-if command -v ${binary_name} > /dev/null 2>&1; then
-    source <(${binary_name} completion bash)
+target_bashrc="${target_home}/.bashrc"
+mkdir -p "${target_home}"
+if [ ! -s "${target_bashrc}" ]; then
+    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
 fi
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+completion_line="source <(${binary_name} completion bash)"
+if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+        echo "${completion_line}"
+    } >> "${target_bashrc}"
+fi
+chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/sops/install.sh
+++ b/src/sops/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/sops/install.sh
+++ b/src/sops/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(bash-completion curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="sops"
 owner_name="getsops"
@@ -21,6 +35,18 @@ else
   fi
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-v${binary_version}.linux.${arch} -o /usr/local/bin/${binary_name} && chmod +x /usr/local/bin/${binary_name}
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
+if [ -r /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+fi
+if command -v ${binary_name} > /dev/null 2>&1; then
+    source <(${binary_name} completion bash)
+fi
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/talosctl/devcontainer-feature.json
+++ b/src/talosctl/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "talosctl",
   "id": "talosctl",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "talosctl is a CLI for out-of-band management of Kubernetes nodes created by Talos.",
   "options": {
     "version": {
@@ -13,9 +13,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'source /usr/share/bash-completion/bash_completion; source <(talosctl completion bash)' >> ~/.bashrc"
+  }
 }

--- a/src/talosctl/install.sh
+++ b/src/talosctl/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq sudo)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,16 +36,27 @@ else
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-linux-${arch} -o /usr/local/bin/${binary_name} && chmod +x /usr/local/bin/${binary_name}
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
-if [ -r /usr/share/bash-completion/bash_completion ]; then
-    . /usr/share/bash-completion/bash_completion
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+if [ "${target_user}" = "root" ]; then
+    target_home="/root"
+else
+    target_home="/home/${target_user}"
 fi
-if command -v ${binary_name} > /dev/null 2>&1; then
-    source <(${binary_name} completion bash)
+target_bashrc="${target_home}/.bashrc"
+mkdir -p "${target_home}"
+if [ ! -s "${target_bashrc}" ]; then
+    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
 fi
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+completion_line="source <(${binary_name} completion bash)"
+if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+    {
+        echo ""
+        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+        echo "${completion_line}"
+    } >> "${target_bashrc}"
+fi
+chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/talosctl/install.sh
+++ b/src/talosctl/install.sh
@@ -39,24 +39,20 @@ fi
 target_user="${_REMOTE_USER:-root}"
 echo "Installing bash completion for ${binary_name} for ${target_user}..."
 if [ "${target_user}" = "root" ]; then
-    target_home="/root"
+    target_bashrc="/root/.bashrc"
 else
-    target_home="/home/${target_user}"
+    target_bashrc="/home/${target_user}/.bashrc"
 fi
-target_bashrc="${target_home}/.bashrc"
-mkdir -p "${target_home}"
-if [ ! -s "${target_bashrc}" ]; then
-    cp /etc/skel/.bashrc "${target_bashrc}" 2>/dev/null || touch "${target_bashrc}"
-fi
-completion_line="source <(${binary_name} completion bash)"
-if ! grep -qF "${completion_line}" "${target_bashrc}" 2>/dev/null; then
+completion_marker="# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
+if ! grep -qF "${completion_marker}" "${target_bashrc}" 2>/dev/null; then
     {
         echo ""
-        echo "# ${binary_name} completion (managed by ${binary_name} devcontainer feature)"
-        echo "${completion_line}"
+        echo "${completion_marker}"
+        echo "source /usr/share/bash-completion/bash_completion"
+        echo "source <(${binary_name} completion bash)"
     } >> "${target_bashrc}"
 fi
-chown "${target_user}:${target_user}" "${target_home}" "${target_bashrc}" 2>/dev/null || true
+chown "${target_user}:${target_user}" "${target_bashrc}" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e

--- a/src/talosctl/install.sh
+++ b/src/talosctl/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(bash-completion curl jq)
+REQUIRED_PACKAGES=(bash-completion ca-certificates curl jq)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/talosctl/install.sh
+++ b/src/talosctl/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(bash-completion curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="talosctl"
 owner_name="siderolabs"
@@ -21,6 +35,18 @@ else
   fi
   curl -sSL https://github.com/${owner_name}/${repo_name}/releases/download/v${binary_version}/${binary_name}-linux-${arch} -o /usr/local/bin/${binary_name} && chmod +x /usr/local/bin/${binary_name}
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<EOF
+if [ -r /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+fi
+if command -v ${binary_name} > /dev/null 2>&1; then
+    source <(${binary_name} completion bash)
+fi
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Terraform",
   "id": "terraform",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Installs the Terraform CLI.",
   "options": {
     "version": {
@@ -30,9 +30,5 @@
         ]
       }
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
-  },
-  "postCreateCommand": "echo 'complete -C /usr/local/bin/terraform terraform' >> ~/.bashrc"
+  }
 }

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(curl jq unzip)
+REQUIRED_PACKAGES=(ca-certificates curl jq unzip)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(curl jq unzip)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="terraform"
 
@@ -21,6 +35,13 @@ else
   rm -f ${binary_name}_${binary_version}_linux_${arch}.zip
   echo "$binary_name installed."
 fi
+
+echo "Installing bash completion for ${binary_name}..."
+cat > /etc/profile.d/${binary_name}-completion.sh <<'EOF'
+complete -C /usr/local/bin/terraform terraform
+EOF
+chmod +x /etc/profile.d/${binary_name}-completion.sh
+echo "Bash completion for ${binary_name} installed."
 
 set +e
 

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-REQUIRED_PACKAGES=(ca-certificates curl jq unzip)
+REQUIRED_PACKAGES=(ca-certificates curl jq sudo unzip)
 
 to_install=()
 for pkg in "${REQUIRED_PACKAGES[@]}"; do
@@ -36,11 +36,9 @@ else
   echo "$binary_name installed."
 fi
 
-echo "Installing bash completion for ${binary_name}..."
-cat > /etc/profile.d/${binary_name}-completion.sh <<'EOF'
-complete -C /usr/local/bin/terraform terraform
-EOF
-chmod +x /etc/profile.d/${binary_name}-completion.sh
+target_user="${_REMOTE_USER:-root}"
+echo "Installing bash completion for ${binary_name} for ${target_user}..."
+sudo -u "${target_user}" -H bash -c "${binary_name} -install-autocomplete" 2>/dev/null || true
 echo "Bash completion for ${binary_name} installed."
 
 set +e


### PR DESCRIPTION
Moves bash completion installation logic back into install.sh (sorry) which makes it self-contained and does not depend on `postCreateCommand`.

Additionally REQUIRED_PACKAGES has been added so only packages needed for installing the feature are installed. This avoids needing the common-utils feature to be installed, and removes the `dependsOn` dependency.

In all, these changes are aimed at making the changed features more self-contained.