### PR TITLE
Replace dependsOn with explicit required packages

### DIFF
--- a/src/age/NOTES.md
+++ b/src/age/NOTES.md
@@ -8,10 +8,14 @@ This feature is tested against the following OS versions:
 - mcr.microsoft.com/devcontainers/base:ubuntu24.04
 - mcr.microsoft.com/devcontainers/base:debian12
 
-Versions older than what are listed above are untested and therefore may not support this feature without additional packages.
+This feature is tested against the following architectures:
+
+- amd64
+- arm64
 
 ## Changelog
 
 | Version | Notes |
 | --- | --- |
+| 2.0.0 | Replace dependsOn with explicit required packages |
 | 1.0.0 | Initial release |

--- a/src/age/devcontainer-feature.json
+++ b/src/age/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "age File Encryption",
   "id": "age",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.",
   "options": {
     "version": {
@@ -13,8 +13,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/age/install.sh
+++ b/src/age/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(ca-certificates curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="age"
 owner_name="FiloSottile"

--- a/src/flux-mcp-server/NOTES.md
+++ b/src/flux-mcp-server/NOTES.md
@@ -17,6 +17,7 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 2.0.0 | Replace dependsOn with explicit required packages |
 | 1.0.2 | Update install and test scripts |
 | 1.0.1 | Surface curl errors |
 | 1.0.0 | Initial release |

--- a/src/flux-mcp-server/devcontainer-feature.json
+++ b/src/flux-mcp-server/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "flux-mcp-server",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "name": "Flux MCP Server",
   "documentationURL": "https://fluxcd.control-plane.io/mcp/",
   "description": "The Flux Model Context Protocol (MCP) Server connects AI assistants like Claude, Cursor, GitHub Copilot, and others directly to your Kubernetes clusters running Flux Operator, enabling seamless interaction through natural language.",
@@ -21,8 +21,5 @@
         "ms-kubernetes-tools.vscode-kubernetes-tools"
       ]
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/flux-mcp-server/install.sh
+++ b/src/flux-mcp-server/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(ca-certificates curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="flux-operator-mcp"
 

--- a/src/github-mcp-server/NOTES.md
+++ b/src/github-mcp-server/NOTES.md
@@ -17,4 +17,5 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 2.0.0 | Replace dependsOn with explicit required packages |
 | 1.0.0 | Initial release |

--- a/src/github-mcp-server/devcontainer-feature.json
+++ b/src/github-mcp-server/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "github-mcp-server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "name": "GitHub MCP Server",
   "documentationURL": "https://github.com/github/github-mcp-server",
   "description": "The GitHub MCP Server connects AI tools directly to GitHub's platform.",
@@ -14,8 +14,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/github-mcp-server/install.sh
+++ b/src/github-mcp-server/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(ca-certificates curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="github-mcp-server"
 

--- a/src/grafana-mcp-server/NOTES.md
+++ b/src/grafana-mcp-server/NOTES.md
@@ -17,4 +17,5 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 2.0.0 | Replace dependsOn with explicit required packages |
 | 1.0.0 | Initial release |

--- a/src/grafana-mcp-server/devcontainer-feature.json
+++ b/src/grafana-mcp-server/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "grafana-mcp-server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "name": "Grafana MCP Server",
   "documentationURL": "https://github.com/grafana/mcp-grafana",
   "description": "MCP server for Grafana.",
@@ -14,8 +14,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/grafana-mcp-server/install.sh
+++ b/src/grafana-mcp-server/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(ca-certificates curl jq)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="mcp-grafana"
 owner_name="grafana"

--- a/src/kubelogin/NOTES.md
+++ b/src/kubelogin/NOTES.md
@@ -3,15 +3,19 @@
 
 This feature is tested against the following OS versions:
 
-- ubuntu:noble
+- ubuntu:24.04
 - debian:12
 - mcr.microsoft.com/devcontainers/base:ubuntu24.04
 - mcr.microsoft.com/devcontainers/base:debian12
 
-Versions older than what are listed above are untested and therefore may not support this feature without additional packages.
+This feature is tested against the following architectures:
+
+- amd64
+- arm64
 
 ## Changelog
 
 | Version | Notes |
 | --- | --- |
+| 2.0.0 | Replace dependsOn with explicit required packages |
 | 1.0.0 | Initial release |

--- a/src/kubelogin/devcontainer-feature.json
+++ b/src/kubelogin/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "kubelogin",
   "id": "kubelogin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "kubectl plugin for Kubernetes OpenID Connect authentication (kubectl oidc-login)",
   "documentationURL": "https://github.com/int128/kubelogin/blob/master/docs/setup.md",
   "options": {
@@ -14,8 +14,5 @@
       ],
       "type": "string"
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/kubelogin/install.sh
+++ b/src/kubelogin/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(ca-certificates curl jq unzip)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="kubelogin"
 owner_name="int128"

--- a/src/terraform-mcp-server/NOTES.md
+++ b/src/terraform-mcp-server/NOTES.md
@@ -17,5 +17,6 @@ This feature is tested against the following architectures:
 
 | Version | Notes |
 | --- | --- |
+| 2.0.0 | Replace dependsOn with explicit required packages |
 | 1.0.1 | Update install script internal vars |
 | 1.0.0 | Initial release |

--- a/src/terraform-mcp-server/devcontainer-feature.json
+++ b/src/terraform-mcp-server/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "terraform-mcp-server",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "name": "Terraform MCP Server",
   "documentationURL": "https://developer.hashicorp.com/terraform/docs/tools/mcp-server",
   "description": "The Terraform MCP Server provides seamless integration with Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development.",
@@ -21,8 +21,5 @@
         "hashicorp.terraform"
       ]
     }
-  },
-  "dependsOn": {
-    "ghcr.io/devcontainers/features/common-utils": {}
   }
 }

--- a/src/terraform-mcp-server/install.sh
+++ b/src/terraform-mcp-server/install.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+REQUIRED_PACKAGES=(ca-certificates curl jq unzip)
+
+to_install=()
+for pkg in "${REQUIRED_PACKAGES[@]}"; do
+    dpkg -s "$pkg" > /dev/null 2>&1 || to_install+=("$pkg")
+done
+
+if (( ${#to_install[@]} > 0 )); then
+    echo "Installing missing packages: ${to_install[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${to_install[@]}"
+    rm -rf /var/lib/apt/lists/*
+fi
+
 VERSION="${VERSION:-latest}"
 binary_name="terraform-mcp-server"
 


### PR DESCRIPTION
Continuing to make these features more self-contained, `dependsOn` has been dropped in favor of declaring required packages in the `install.sh`.